### PR TITLE
Fixed _obtain_input_shape import error

### DIFF
--- a/resnext.py
+++ b/resnext.py
@@ -20,7 +20,7 @@ from keras.regularizers import l2
 from keras.utils.layer_utils import convert_all_kernels_in_model
 from keras.utils.data_utils import get_file
 from keras.engine.topology import get_source_inputs
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 import keras.backend as K
 
 CIFAR_TH_WEIGHTS_PATH = ''


### PR DESCRIPTION
I replaced keras.applications.imagenet_utils with keras_applications.imagenet_utils, which fixes that error.